### PR TITLE
Force chef run to include svn directory in PATH

### DIFF
--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -28,6 +28,10 @@ when 'windows'
   windows_path 'C:\Program Files (x86)\Subversion\bin' do
     action :add
   end
+
+  unless ENV['PATH'].include? 'C:\Program Files (x86)\Subversion\bin'
+    ENV['PATH'] = ENV['PATH'] + ';C:\Program Files (x86)\Subversion\bin'
+  end
 else
   package 'subversion' do
     action :install


### PR DESCRIPTION
Somewhat hackish workaround for opscode-cookbooks/subversion#19 where the svn path is not added to ENV['PATH'] by default, causing further commands to fail.

This is likely due to an upstream bug, but this works around the issue for now.
