### PR TITLE
Chef CLient 13 Amazon Platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ subversion Cookbook CHANGELOG
 =============================
 This file is used to list changes made in each version of the subversion cookbook.
 
+## 2.1.2 (2017-08-07)
+
+- Add Amazon as a platform in client.rb recipe
+
 ## 2.1.1 (2016-12-31)
 
 - Loosen the Windows cookbook dependency

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Installs subversion'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.1.1'
+version '2.1.2'
 
 %w(fedora ubuntu debian redhat centos suse scientific oracle amazon windows).each do |os|
   supports os

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -39,7 +39,7 @@ else
 
   extra_packages = value_for_platform_family(
     'debian' => %w(subversion-tools libsvn-perl),
-    %w(rhel fedora suse) => %w(subversion-devel subversion-perl)
+    %w(rhel fedora suse amazon) => %w(subversion-devel subversion-perl)
   )
 
   extra_packages.each do |name|


### PR DESCRIPTION
### Description

- Add Amazon as a platform in client.rb recipe

### Issues Resolved

Allows cookbook to work on AWS EC2 instance running AWS Linux and Chef Client 13.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
